### PR TITLE
Warn when find.py --airport is used without procedure flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Examples:
 
 A Find function is available to generate example manifests. For example, running the command `python3 find.py --airport KIAD --sid --star --iap --centerlines` will generate a manifest called `generated_kiad.json` in the `./manifests` directory containing all SIDs, STARs, IAPs, and Centerlines for `KIAD`. All defaults are included so that you can modify them if you desire, or delete lines if you are okay with the default.
 
+> **Note:** `--airport` alone does not generate any output. You must specify at least one procedure flag (`--sid`, `--star`, `--iap`, or `--centerlines`).
+
 For more detail, see [FIND](./readme/FIND.md).
 
 ## Drawing the Facility

--- a/find.py
+++ b/find.py
@@ -19,6 +19,7 @@ from modules.runway import split_runway_id
 import argparse
 import os
 import sqlite3
+import sys
 
 DB_FILE_PATH = f"{NAVDATA_DIR}/FAACIFP18.db"
 GENERATED_PREFIX = "generated"
@@ -94,6 +95,20 @@ if os.path.exists(DB_FILE_PATH):
 
     if airport_id:
         airport_id = airport_id.upper()
+        if not any([find_sid, find_star, find_iap, find_centerlines]):
+            print(
+                f"Warning: --airport {airport_id} was provided without any procedure flags."
+            )
+            print(
+                "No manifest content will be generated. Use one or more of the following:"
+            )
+            print("  --sid          Generate SIDs")
+            print("  --star         Generate STARs")
+            print("  --iap          Generate IAPs")
+            print("  --centerlines  Generate Centerlines")
+            print()
+            print(f"Example: python3 find.py --airport {airport_id} --sid --star")
+            sys.exit(1)
         manifest = Manifest()
         map_id = 1
 

--- a/readme/FIND.md
+++ b/readme/FIND.md
@@ -17,10 +17,16 @@ By default, the manifests are created in a STARS format. The `--eram` switch is 
 | `--iap`         | [IAP](./IAP.md)                 |
 | `--centerlines` | [CENTERLINES](./CENTERLINES.md) |
 
+> **Important:** `--airport` requires at least one of the switches above. Running `--airport` without any procedure flag will display a warning and exit without generating a manifest.
+
 An additional `--select` switch is available when using `--centerlines`, which tries to find an appropriate IAP for the runway, and adds it to the manifest if found.
 
 ```bash
-python3 find.py --airport {airport_id} {--optional switches}
+# Correct: specify at least one procedure flag
+python3 find.py --airport KIAH --sid --star
+
+# This will NOT work (no procedure flags):
+# python3 find.py --airport KIAH
 ```
 
 #### Other Commands


### PR DESCRIPTION
## Summary

- Adds a warning message and exits when `find.py --airport` is used without any procedure flags (`--sid`, `--star`, `--iap`, `--centerlines`), guiding the user toward correct usage.
- Updates **README.md** and **readme/FIND.md** with a note clarifying that `--airport` alone does not generate output.

Addresses #1

## Example output

`
Warning: --airport KIAH was provided without any procedure flags.
No manifest content will be generated. Use one or more of the following:
  --sid          Generate SIDs
  --star         Generate STARs
  --iap          Generate IAPs
  --centerlines  Generate Centerlines

Example: python3 find.py --airport KIAH --sid --star
`

Made with [Cursor](https://cursor.com)